### PR TITLE
fix: add option to esbuild to prevent constructor names being changed, causing conflicts in parsers

### DIFF
--- a/build.js
+++ b/build.js
@@ -5,6 +5,7 @@ build({
     external: ['antlr4ng', 'antlr4-c3'],
     bundle: true,
     minify: true,
+    keepNames: true,
     format: 'esm',
     outfile: 'dist/index.js',
     tsconfig: './tsconfig.build.json',


### PR DESCRIPTION
Closes #ISSUE_ID
