### PR TITLE
fix(YQL): keyword suggestion at ID_QUOTED

### DIFF
--- a/src/autocomplete/databases/yql/helpers.ts
+++ b/src/autocomplete/databases/yql/helpers.ts
@@ -41,6 +41,13 @@ function isFirstPreviousTokenOfType(
     return false;
 }
 
+export function checkShouldSuggestKeywords(
+    cursorTokenIndex: number,
+    tokenStream: TokenStream,
+): boolean {
+    return tokenStream.get(cursorTokenIndex)?.type !== YQLParser.ID_QUOTED;
+}
+
 function getRuleCheckHelpers(ruleList: c3.RuleList): {
     anyRuleInList: AnyRuleInList;
     allRulesInList: AllRulesInList;

--- a/src/autocomplete/databases/yql/tests/yql/select/select.test.ts
+++ b/src/autocomplete/databases/yql/tests/yql/select/select.test.ts
@@ -39,11 +39,19 @@ test('should suggest properly after SELECT', () => {
     expect(autocompleteResult.suggestUdfs).toBeTruthy();
     expect(autocompleteResult.suggestSimpleTypes).toBeTruthy();
 });
+
 test('should suggest properly after FROM', () => {
     const autocompleteResult = parseYqlQueryWithCursor('FROM |');
 
     const keywordsSuggestion: KeywordSuggestion[] = [{value: 'ANY'}];
     expect(autocompleteResult.suggestKeywords).toEqual(keywordsSuggestion);
+    expect(autocompleteResult.suggestEntity).toEqual(['table', 'view', 'externalTable']);
+});
+
+test('should suggest properly after FROM between BACKTICKs', () => {
+    const autocompleteResult = parseYqlQueryWithCursor('FROM `|`');
+
+    expect(autocompleteResult.suggestKeywords).toEqual([]);
     expect(autocompleteResult.suggestEntity).toEqual(['table', 'view', 'externalTable']);
 });
 

--- a/src/autocomplete/databases/yql/tests/yql/select/select.test.ts
+++ b/src/autocomplete/databases/yql/tests/yql/select/select.test.ts
@@ -48,11 +48,27 @@ test('should suggest properly after FROM', () => {
     expect(autocompleteResult.suggestEntity).toEqual(['table', 'view', 'externalTable']);
 });
 
-test('should suggest properly after FROM between BACKTICKs', () => {
-    const autocompleteResult = parseYqlQueryWithCursor('FROM `|`');
-
-    expect(autocompleteResult.suggestKeywords).toEqual([]);
-    expect(autocompleteResult.suggestEntity).toEqual(['table', 'view', 'externalTable']);
+test('should suggest properly after FROM at ID_QUOTED', () => {
+    {
+        const autocompleteResult = parseYqlQueryWithCursor('FROM `|`');
+        expect(autocompleteResult.suggestKeywords).toEqual([]);
+    }
+    {
+        const autocompleteResult = parseYqlQueryWithCursor('FROM `|');
+        expect(autocompleteResult.suggestKeywords).toEqual([{value: 'ANY'}]);
+    }
+    {
+        const autocompleteResult = parseYqlQueryWithCursor('FROM ` |');
+        expect(autocompleteResult.suggestKeywords).toEqual([{value: 'ANY'}]);
+    }
+    {
+        const autocompleteResult = parseYqlQueryWithCursor('FROM ``|');
+        expect(autocompleteResult.suggestKeywords?.length).toBeGreaterThan(0);
+    }
+    {
+        const autocompleteResult = parseYqlQueryWithCursor('FROM `` |');
+        expect(autocompleteResult.suggestKeywords?.length).toBeGreaterThan(0);
+    }
 });
 
 test('should suggest properly after *', () => {

--- a/src/autocomplete/databases/yql/yql-autocomplete.ts
+++ b/src/autocomplete/databases/yql/yql-autocomplete.ts
@@ -35,7 +35,12 @@ import {
 import {ColumnAliasSymbol, TableSymbol, VariableSymbol} from '../../shared/symbol-table.js';
 import {isStartingToWriteRule} from '../../shared/cursor.js';
 import {shouldSuggestTemplates} from '../../shared/query.js';
-import {EntitySuggestionToYqlEntity, getGranularSuggestions, tokenDictionary} from './helpers';
+import {
+    EntitySuggestionToYqlEntity,
+    getGranularSuggestions,
+    tokenDictionary,
+    checkShouldSuggestKeywords,
+} from './helpers';
 import {EntitySuggestion, InternalSuggestions, YqlAutocompleteResult} from './types';
 import {getVariableSuggestions} from '../../shared/variables';
 import {getExtendedTableSuggestions} from '../../shared/extended-tables';
@@ -539,6 +544,10 @@ function getEnrichAutocompleteResult(parseTreeGetter: GetParseTree<YQLParser>) {
             if (shouldSuggestColumnAliases && suggestColumnAliases) {
                 result.suggestColumnAliases = suggestColumnAliases;
             }
+        }
+
+        if (!checkShouldSuggestKeywords(cursorTokenIndex, tokenStream)) {
+            result.suggestKeywords = [];
         }
 
         return result;

--- a/src/autocomplete/databases/yql/yql-autocomplete.ts
+++ b/src/autocomplete/databases/yql/yql-autocomplete.ts
@@ -36,10 +36,10 @@ import {ColumnAliasSymbol, TableSymbol, VariableSymbol} from '../../shared/symbo
 import {isStartingToWriteRule} from '../../shared/cursor.js';
 import {shouldSuggestTemplates} from '../../shared/query.js';
 import {
+    checkShouldSuggestKeywords,
     EntitySuggestionToYqlEntity,
     getGranularSuggestions,
     tokenDictionary,
-    checkShouldSuggestKeywords,
 } from './helpers';
 import {EntitySuggestion, InternalSuggestions, YqlAutocompleteResult} from './types';
 import {getVariableSuggestions} from '../../shared/variables';

--- a/src/autocomplete/databases/yql/yql-autocomplete.ts
+++ b/src/autocomplete/databases/yql/yql-autocomplete.ts
@@ -36,8 +36,8 @@ import {ColumnAliasSymbol, TableSymbol, VariableSymbol} from '../../shared/symbo
 import {isStartingToWriteRule} from '../../shared/cursor.js';
 import {shouldSuggestTemplates} from '../../shared/query.js';
 import {
-    checkShouldSuggestKeywords,
     EntitySuggestionToYqlEntity,
+    checkShouldSuggestKeywords,
     getGranularSuggestions,
     tokenDictionary,
 } from './helpers';


### PR DESCRIPTION
- Fix of #285

Problem is that actually in that position `ANY` is a valid keyword and engine does not care if cursor at the middle of a quoted identifier, so I added a hack to walk around it.

Not sure that code is placed in conceptually right position and `enrichAutocompleteResults` name semantics is broken, so your opinion is required how to organize the change.